### PR TITLE
Optional custom input key names, input validation (CheckInput)

### DIFF
--- a/src/measureia/Sim_info.py
+++ b/src/measureia/Sim_info.py
@@ -152,7 +152,7 @@ class SimInfo:
 			self.N_files = 600
 		elif self.simname == "EAGLE":
 			znames = {"28": "z000p000", "17": "z001p487", "19": "z001p004", "21": "z000p736", "23": "z000p503",
-					  "25": "z000p271"}
+					  "25": "z000p271", None: None}
 			zname = znames[self.snapshot]
 			self.snap_folder = f"/snap_0{self.snapshot}/RefL0100N1504/snapshot_0{self.snapshot}_{zname}/snap_0{self.snapshot}_{zname}"  # update for different z?
 			self.fof_folder = None

--- a/src/measureia/__init__.py
+++ b/src/measureia/__init__.py
@@ -4,6 +4,7 @@
 from .measure_IA import MeasureIABox
 from .measure_IA_lightcone import MeasureIALightcone
 from .measure_IA_base import MeasureIABase
+from .check_input import CheckInput
 
 # import covariance measurement class
 from .measure_jackknife import MeasureJackknife

--- a/src/measureia/check_input.py
+++ b/src/measureia/check_input.py
@@ -1,0 +1,154 @@
+import os
+import warnings
+import numpy as np
+
+
+class CheckInput:
+	"""Class that contains static methods to validate the input data of MeasureIABox and MeasureIALightcone and to
+	translate user-defined data dictionary key names to the internal (default) names.
+
+	Methods
+	-------
+	check_dict()
+		Check that a data dictionary contains all required keys.
+	check_paths()
+		Check that the folder of each given file path exists.
+	check_units_coordinates()
+		Check that coordinates fall within [0, boxsize].
+	check_type_input_data()
+		Check types and shapes of the entries of the input data dictionary.
+	check_jackknife_max_separation()
+		Warn if the maximum separation or number of r bins is too large for the jackknife subbox size.
+	rename_input_keys()
+		Return a shallow copy of a data dictionary with user-defined key names replaced by the internal names.
+
+	"""
+
+	@staticmethod
+	def check_dict(dict, names):
+		"""Checks that all keys in 'names' exist in the given dictionary.
+
+		Parameters
+		----------
+		dict : dict
+			Data dictionary to check.
+		names : iterable of str
+			Names of the keys that must be present.
+
+		"""
+		for name in names:
+			if name not in dict:
+				raise KeyError(f"Your data dictionary does not contain {name}.")
+		return
+
+	@staticmethod
+	def check_paths(paths):
+		"""Checks that the folder of each given file path exists.
+
+		Parameters
+		----------
+		paths : iterable of str
+			File paths whose parent folders are checked.
+
+		"""
+		for path in paths:
+			folder_path = os.path.dirname(path) or "."
+			if not os.path.exists(folder_path):
+				raise FileNotFoundError(f"{path} does not exist.")
+		return
+
+	@staticmethod
+	def check_units_coordinates(coordinates, boxsize):
+		"""Checks that the coordinates fall within [0, boxsize].
+
+		Parameters
+		----------
+		coordinates : ndarray
+			(N,3) array of positions.
+		boxsize : float
+			Size of the simulation box, in the same units as the coordinates.
+
+		"""
+		for i in np.arange(0, len(coordinates[0])):
+			if min(coordinates[:, i]) < 0. or max(coordinates[:, i]) > boxsize:
+				raise ValueError(
+					"The coordinates do not agree with the boxsize. They should be in range [0, boxsize]. Check the units.")
+		return
+
+	@staticmethod
+	def check_type_input_data(dict, names):
+		"""Checks types and shapes of the entries of the input data dictionary for MeasureIABox.
+
+		Parameters
+		----------
+		dict : dict
+			Data dictionary to check.
+		names : iterable of 5 str
+			Key names of the positions of the density sample, positions of the shape sample, axis directions,
+			axis ratios and line-of-sight index, in that order.
+
+		"""
+		(positions_density_sample_name, positions_shape_sample_name, axis_direction_name, axis_ratio_name,
+		 line_of_sight_index_name) = names
+		assert type(dict[positions_density_sample_name]) == np.ndarray
+		assert np.shape(dict[positions_density_sample_name])[1] == 3
+		assert type(dict[positions_shape_sample_name]) == np.ndarray
+		assert np.shape(dict[positions_shape_sample_name])[1] == 3
+		assert type(dict[axis_direction_name]) == np.ndarray
+		assert np.shape(dict[axis_direction_name])[1] == 2
+		assert type(dict[axis_ratio_name]) == np.ndarray
+		assert len(np.shape(dict[axis_ratio_name])) == 1
+		assert type(dict[line_of_sight_index_name]) == int
+		assert (dict[line_of_sight_index_name] == 0) or (dict[line_of_sight_index_name] == 1) or (
+				dict[line_of_sight_index_name] == 2)
+		return
+
+	@staticmethod
+	def check_jackknife_max_separation(num_jk, boxsize, max_separation, num_r_bins):
+		"""Warns if the maximum separation or the number of r bins is large compared to the jackknife subbox size.
+
+		Parameters
+		----------
+		num_jk : int
+			Number of jackknife realisations.
+		boxsize : float
+			Size of the simulation box.
+		max_separation : float
+			Maximum (projected) separation of the measurement.
+		num_r_bins : int
+			Number of (projected) separation bins.
+
+		"""
+		L_box = boxsize / num_jk ** (1. / 3)
+		if max_separation > L_box:
+			warnings.warn(
+				"WARNING: your maximum separation exceeds the size of your jackknife subboxes. This is not recommended. "
+				"Please lower the number of jackknife realisations or your maximum separation.")
+		if num_r_bins ** (3. / 2) > L_box:
+			warnings.warn(
+				"WARNING: You have too many r(p) bins for your number of jackknife realisation. This is not recommended. "
+				"Please lower the number of r(p) bins or increase your number of jackknife realisations.")
+		return
+
+	@staticmethod
+	def rename_input_keys(input_dict, name_map):
+		"""Returns a shallow copy of a data (or mask) dictionary in which user-defined key names are replaced by the
+		internal default names. Keys that do not appear in the name map are kept unchanged, the data itself is not
+		copied. If None is given, None is returned.
+
+		Parameters
+		----------
+		input_dict : dict or NoneType
+			Data or mask dictionary with user-defined key names.
+		name_map : dict
+			Mapping of user-defined key names to internal default names.
+
+		Returns
+		-------
+		dict or NoneType
+			Dictionary with the internal default key names.
+
+		"""
+		if input_dict is None:
+			return None
+		return {name_map.get(key, key): value for key, value in input_dict.items()}

--- a/src/measureia/measure_IA.py
+++ b/src/measureia/measure_IA.py
@@ -91,7 +91,8 @@ class MeasureIABox(MeasureWBox, MeasureMultipolesBox, MeasureWBoxJackknife, Meas
 			weight_density_sample_name: "weight",
 			weight_shape_sample_name: "weight_shape_sample",
 		}
-		self.check_paths([output_file_name])
+		if output_file_name is not None:
+			self.check_paths([output_file_name])
 		if data is not None:
 			self.check_dict(data, [positions_density_sample_name, positions_shape_sample_name, axis_direction_name,
 								   axis_ratio_name, line_of_sight_index_name])

--- a/src/measureia/measure_IA.py
+++ b/src/measureia/measure_IA.py
@@ -5,9 +5,11 @@ from .measure_m_box_jk import MeasureMBoxJackknife
 from .measure_w_box import MeasureWBox
 from .measure_m_box import MeasureMultipolesBox
 from .measure_jackknife import MeasureJackknife
+from .check_input import CheckInput
 
 
-class MeasureIABox(MeasureWBox, MeasureMultipolesBox, MeasureWBoxJackknife, MeasureMBoxJackknife, MeasureJackknife):
+class MeasureIABox(MeasureWBox, MeasureMultipolesBox, MeasureWBoxJackknife, MeasureMBoxJackknife, MeasureJackknife,
+				   CheckInput):
 	r"""Manages the IA correlation function measurement methods used in the MeasureIA package based on speed and input.
 	This class is used to call the methods that measure $w_{gg}$, $w_{g+}$ and multipoles for simulations in cartesian
 	coordinates. Depending on the input parameters, various correlations incl covariance estimates are measured for
@@ -41,6 +43,13 @@ class MeasureIABox(MeasureWBox, MeasureMultipolesBox, MeasureWBoxJackknife, Meas
 			boxsize=None,
 			periodicity=True,
 			num_nodes=1,
+			positions_density_sample_name="Position",
+			positions_shape_sample_name="Position_shape_sample",
+			axis_direction_name="Axis_Direction",
+			axis_ratio_name="q",
+			line_of_sight_index_name="LOS",
+			weight_density_sample_name="weight",
+			weight_shape_sample_name="weight_shape_sample",
 	):
 		"""
 		The __init__ method of the MeasureIABox class.
@@ -49,15 +58,51 @@ class MeasureIABox(MeasureWBox, MeasureMultipolesBox, MeasureWBoxJackknife, Meas
 		----------
 		num_nodes : int, optional
 			Number of cores to be used in multiprocessing. Default is 1.
+		positions_density_sample_name : str, optional
+			Name of the key in the data dictionary that contains the positions of the density sample.
+		positions_shape_sample_name : str, optional
+			Name of the key in the data dictionary that contains the positions of the shape sample.
+		axis_direction_name : str, optional
+			Name of the key in the data dictionary that contains the axis direction vectors of the shape sample.
+		axis_ratio_name : str, optional
+			Name of the key in the data dictionary that contains the axis ratios of the shape sample.
+		line_of_sight_index_name : str, optional
+			Name of the key in the data dictionary that contains the column index of the line of sight in the
+			position vectors.
+		weight_density_sample_name : str, optional
+			Name of the key in the data dictionary that contains the weights of the density sample.
+		weight_shape_sample_name : str, optional
+			Name of the key in the data dictionary that contains the weights of the shape sample.
 
 		Notes
 		-----
 		Constructor parameters 'data', 'output_file_name', 'simulation', 'snapshot', 'separation_limits', 'num_bins_r',
 		'num_bins_pi', 'pi_max', 'boxsize' and 'periodicity' are passed to MeasureIABase.
+		The data dictionary (and any mask dictionaries passed to the measurement methods) may use any key names;
+		they are given through the *_name parameters and translated to the internal default names on input.
 
 		"""
+		self._input_name_map = {
+			positions_density_sample_name: "Position",
+			positions_shape_sample_name: "Position_shape_sample",
+			axis_direction_name: "Axis_Direction",
+			axis_ratio_name: "q",
+			line_of_sight_index_name: "LOS",
+			weight_density_sample_name: "weight",
+			weight_shape_sample_name: "weight_shape_sample",
+		}
+		self.check_paths([output_file_name])
+		if data is not None:
+			self.check_dict(data, [positions_density_sample_name, positions_shape_sample_name, axis_direction_name,
+								   axis_ratio_name, line_of_sight_index_name])
+			self.check_type_input_data(data,
+									   (positions_density_sample_name, positions_shape_sample_name, axis_direction_name,
+										axis_ratio_name, line_of_sight_index_name))
+			data = self.rename_input_keys(data, self._input_name_map)
 		super().__init__(data, output_file_name, simulation, snapshot, separation_limits, num_bins_r, num_bins_pi,
 						 pi_max, boxsize, periodicity)
+		if self.data is not None and self.boxsize is not None:
+			self.check_units_coordinates(self.data["Position"], self.boxsize)
 		self.num_nodes = num_nodes
 		self.randoms_data = None
 		self.data_dir = None
@@ -93,10 +138,12 @@ class MeasureIABox(MeasureWBox, MeasureMultipolesBox, MeasureWBoxJackknife, Meas
 
 		"""
 		self.responsivity_correction = responsivity
+		masks = self.rename_input_keys(masks, self._input_name_map)
 		if num_jk > 0:
 			try:
 				assert sympy.integer_nthroot(num_jk, 3)[1]
 				L = sympy.integer_nthroot(num_jk, 3)[0]
+				self.check_jackknife_max_separation(num_jk, self.boxsize, self.r_max, self.num_bins_r)
 			except AssertionError:
 				raise ValueError(
 					f"Use x^3 as input for num_jk, with x as an int. {float(int(num_jk ** (1. / 3)))},{num_jk ** (1. / 3)}")
@@ -192,10 +239,12 @@ class MeasureIABox(MeasureWBox, MeasureMultipolesBox, MeasureWBoxJackknife, Meas
 		"""
 
 		self.responsivity_correction = responsivity
+		masks = self.rename_input_keys(masks, self._input_name_map)
 		if num_jk > 0:
 			try:
 				assert sympy.integer_nthroot(num_jk, 3)[1]
 				L = sympy.integer_nthroot(num_jk, 3)[0]
+				self.check_jackknife_max_separation(num_jk, self.boxsize, self.r_max, self.num_bins_r)
 			except AssertionError:
 				raise ValueError(
 					f"Use x^3 as input for num_jk, with x as an int. {float(int(num_jk ** (1. / 3)))},{num_jk ** (1. / 3)}")

--- a/src/measureia/measure_IA_lightcone.py
+++ b/src/measureia/measure_IA_lightcone.py
@@ -4,10 +4,11 @@ from .measure_w_lightcone import MeasureWLightcone
 from .measure_m_lightcone_jk import MeasureMultipolesLightconeJackknife
 from .measure_m_lightcone import MeasureMultipolesLightcone
 from .measure_jackknife import MeasureJackknife
+from .check_input import CheckInput
 
 
 class MeasureIALightcone(MeasureWLightcone, MeasureMultipolesLightcone, MeasureWLightconeJackknife,
-						 MeasureMultipolesLightconeJackknife, MeasureJackknife):
+						 MeasureMultipolesLightconeJackknife, MeasureJackknife, CheckInput):
 	r"""Manages the IA correlation function measurement methods used in the MeasureIA package based on speed and input.
 	This class is used to call the methods that measure w_gg, w_g+ and multipoles for simulations (and observations),
 	with lightcone data.
@@ -47,6 +48,16 @@ class MeasureIALightcone(MeasureWLightcone, MeasureMultipolesLightcone, MeasureW
 			num_bins_pi=20,
 			pi_max=None,
 			num_nodes=1,
+			RA_density_sample_name="RA",
+			RA_shape_sample_name="RA_shape_sample",
+			DEC_density_sample_name="DEC",
+			DEC_shape_sample_name="DEC_shape_sample",
+			redshift_density_sample_name="Redshift",
+			redshift_shape_sample_name="Redshift_shape_sample",
+			e1_name="e1",
+			e2_name="e2",
+			weight_density_sample_name="weight",
+			weight_shape_sample_name="weight_shape_sample",
 	):
 		"""
 		The __init__ method of the MeasureIALightcone class.
@@ -62,13 +73,57 @@ class MeasureIALightcone(MeasureWLightcone, MeasureMultipolesLightcone, MeasureW
 			If only 'Redshift', 'RA' and 'DEC' are added, the sample will be used for both position and shape sample randoms.
 		num_nodes : int, optional
 			Number of cores to be used in multiprocessing. Default is 1.
+		RA_density_sample_name : str, optional
+			Name of the key in the data (and randoms) dictionary that contains the RA of the density sample.
+		RA_shape_sample_name : str, optional
+			Name of the key in the data (and randoms) dictionary that contains the RA of the shape sample.
+		DEC_density_sample_name : str, optional
+			Name of the key in the data (and randoms) dictionary that contains the DEC of the density sample.
+		DEC_shape_sample_name : str, optional
+			Name of the key in the data (and randoms) dictionary that contains the DEC of the shape sample.
+		redshift_density_sample_name : str, optional
+			Name of the key in the data (and randoms) dictionary that contains the redshift of the density sample.
+		redshift_shape_sample_name : str, optional
+			Name of the key in the data (and randoms) dictionary that contains the redshift of the shape sample.
+		e1_name : str, optional
+			Name of the key in the data dictionary that contains the first ellipticity component of the shape sample.
+		e2_name : str, optional
+			Name of the key in the data dictionary that contains the second ellipticity component of the shape sample.
+		weight_density_sample_name : str, optional
+			Name of the key in the data (and randoms) dictionary that contains the weights of the density sample.
+		weight_shape_sample_name : str, optional
+			Name of the key in the data (and randoms) dictionary that contains the weights of the shape sample.
 
 		Notes
 		-----
 		Constructor parameters 'data', 'output_file_name', 'separation_limits', 'num_bins_r',
 		'num_bins_pi', 'pi_max', are passed to MeasureIABase.
+		The data, randoms and mask dictionaries may use any key names; they are given through the *_name
+		parameters and translated to the internal default names on input.
 
 		"""
+		self._input_name_map = {
+			RA_density_sample_name: "RA",
+			RA_shape_sample_name: "RA_shape_sample",
+			DEC_density_sample_name: "DEC",
+			DEC_shape_sample_name: "DEC_shape_sample",
+			redshift_density_sample_name: "Redshift",
+			redshift_shape_sample_name: "Redshift_shape_sample",
+			e1_name: "e1",
+			e2_name: "e2",
+			weight_density_sample_name: "weight",
+			weight_shape_sample_name: "weight_shape_sample",
+		}
+		self.check_paths([output_file_name])
+		if data is not None:
+			self.check_dict(data, [RA_density_sample_name, RA_shape_sample_name, DEC_density_sample_name,
+								   DEC_shape_sample_name, redshift_density_sample_name, redshift_shape_sample_name,
+								   e1_name, e2_name])
+			data = self.rename_input_keys(data, self._input_name_map)
+		if randoms_data is not None:
+			self.check_dict(randoms_data,
+							[RA_density_sample_name, DEC_density_sample_name, redshift_density_sample_name])
+			randoms_data = self.rename_input_keys(randoms_data, self._input_name_map)
 		super().__init__(data, output_file_name, False, None, separation_limits, num_bins_r, num_bins_pi,
 						 pi_max, None, False)
 		self.num_nodes = num_nodes
@@ -410,6 +465,8 @@ class MeasureIALightcone(MeasureWLightcone, MeasureMultipolesLightcone, MeasureW
 			raise KeyError("Unknown input for IA_estimator, choose from [clusters, galaxies].")
 
 		self.responsivity_correction = responsivity
+		masks = self.rename_input_keys(masks, self._input_name_map)
+		masks_randoms = self.rename_input_keys(masks_randoms, self._input_name_map)
 		# todo: Expand to include methods with trees and internal multiproc
 		# todo: Checks to see if data directories include everything they need
 		data = self.data  # temporary save so it can be restored at the end of the calculation
@@ -621,6 +678,8 @@ class MeasureIALightcone(MeasureWLightcone, MeasureMultipolesLightcone, MeasureW
 			raise KeyError("Unknown input for IA_estimator, choose from [clusters, galaxies].")
 
 		self.responsivity_correction = responsivity
+		masks = self.rename_input_keys(masks, self._input_name_map)
+		masks_randoms = self.rename_input_keys(masks_randoms, self._input_name_map)
 		# todo: Expand to include methods with trees and internal multiproc
 		# todo: Checks to see if data directories include everything they need
 		data = self.data  # temporary save so it can be restored at the end of the calculation

--- a/src/measureia/measure_IA_lightcone.py
+++ b/src/measureia/measure_IA_lightcone.py
@@ -114,7 +114,8 @@ class MeasureIALightcone(MeasureWLightcone, MeasureMultipolesLightcone, MeasureW
 			weight_density_sample_name: "weight",
 			weight_shape_sample_name: "weight_shape_sample",
 		}
-		self.check_paths([output_file_name])
+		if output_file_name is not None:
+			self.check_paths([output_file_name])
 		if data is not None:
 			self.check_dict(data, [RA_density_sample_name, RA_shape_sample_name, DEC_density_sample_name,
 								   DEC_shape_sample_name, redshift_density_sample_name, redshift_shape_sample_name,

--- a/src/measureia/read_data.py
+++ b/src/measureia/read_data.py
@@ -150,7 +150,10 @@ class ReadData(SimInfo):
 			Nfiles = self.N_files
 
 		for n in np.arange(1, Nfiles):
-			subhalo_file = h5py.File(f"{self.data_path}{self.fof_folder}.{n}.hdf5", "r")
+			try:
+				subhalo_file = h5py.File(f"{self.data_path}{self.fof_folder}.{n}.hdf5", "r")
+			except OSError as e:
+				raise OSError(f"Could not open file {n} ({self.data_path}{self.fof_folder}.{n}.hdf5).") from e
 			try:
 				Subhalo = subhalo_file[self.catalogue]
 				data_n = Subhalo[dataset_name][:]  # get data single file

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -1,0 +1,294 @@
+"""
+test_inputs.py
+==============
+Tests for the CheckInput class and the custom input-key-name (remap-at-entry)
+support in MeasureIABox and MeasureIALightcone.
+
+Ported from the April limit_input_options branch (1639c90) onto the current
+suite: the original try/except tests are rewritten with pytest.raises /
+pytest.warns, and equivalence tests are added that verify custom key names
+produce bit-identical results to the default names.
+"""
+
+import math
+import numpy as np
+import pytest
+import h5py
+import warnings
+
+from measureia import MeasureIABox, MeasureIALightcone, CheckInput
+
+
+BOXSIZE = 205.0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _box_catalog(N=60, seed=11):
+    rng = np.random.default_rng(seed)
+    theta = rng.uniform(0.0, 2.0 * math.pi, N)
+    return {
+        "Position":              rng.uniform(0.0, BOXSIZE, (N, 3)),
+        "Position_shape_sample": rng.uniform(0.0, BOXSIZE, (N, 3)),
+        "Axis_Direction":        np.column_stack([np.cos(theta), np.sin(theta)]),
+        "LOS":                   2,
+        "q":                     rng.uniform(0.1, 1.0, N),
+    }
+
+
+_BOX_RENAME = {
+    "Position": "COM",
+    "Position_shape_sample": "COM_shape",
+    "Axis_Direction": "e_dir",
+    "q": "axis_ratio",
+    "LOS": "los_index",
+}
+
+_BOX_NAME_KWARGS = {
+    "positions_density_sample_name": "COM",
+    "positions_shape_sample_name": "COM_shape",
+    "axis_direction_name": "e_dir",
+    "axis_ratio_name": "axis_ratio",
+    "line_of_sight_index_name": "los_index",
+}
+
+
+def _lc_catalogs(N=80, NR=240, seed=13):
+    rng = np.random.default_rng(seed)
+
+    def sky(n):
+        return {
+            "RA":                    rng.uniform(150.0, 155.0, n),
+            "DEC":                   rng.uniform(2.0, 6.0, n),
+            "Redshift":              rng.uniform(0.1, 0.3, n),
+            "RA_shape_sample":       rng.uniform(150.0, 155.0, n),
+            "DEC_shape_sample":      rng.uniform(2.0, 6.0, n),
+            "Redshift_shape_sample": rng.uniform(0.1, 0.3, n),
+        }
+
+    data = sky(N)
+    data["e1"] = rng.uniform(-0.5, 0.5, N)
+    data["e2"] = rng.uniform(-0.5, 0.5, N)
+    randoms = sky(NR)
+    return data, randoms
+
+
+_LC_RENAME = {
+    "RA": "ra_d", "RA_shape_sample": "ra_s",
+    "DEC": "dec_d", "DEC_shape_sample": "dec_s",
+    "Redshift": "z_d", "Redshift_shape_sample": "z_s",
+    "e1": "eps1", "e2": "eps2",
+}
+
+_LC_NAME_KWARGS = {
+    "RA_density_sample_name": "ra_d", "RA_shape_sample_name": "ra_s",
+    "DEC_density_sample_name": "dec_d", "DEC_shape_sample_name": "dec_s",
+    "redshift_density_sample_name": "z_d", "redshift_shape_sample_name": "z_s",
+    "e1_name": "eps1", "e2_name": "eps2",
+}
+
+
+def _renamed(cat, mapping):
+    return {mapping.get(k, k): v for k, v in cat.items()}
+
+
+# ---------------------------------------------------------------------------
+# 1. CheckInput unit tests
+# ---------------------------------------------------------------------------
+
+class TestCheckInput:
+    def test_check_dict_raises_on_missing_key(self):
+        with pytest.raises(KeyError, match="does not contain q"):
+            CheckInput.check_dict({"Position": 1}, ["Position", "q"])
+
+    def test_check_paths_missing_folder(self):
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            CheckInput.check_paths(["/nonexistent_folder_xyz/out.hdf5"])
+
+    def test_check_paths_bare_filename_ok(self):
+        CheckInput.check_paths(["out.hdf5"])  # dirname == "" -> cwd, must not raise
+
+    def test_check_units_coordinates(self):
+        coords = np.array([[1.0, 2.0, 1.0], [1.0, 1.0, 1.0]])
+        with pytest.raises(ValueError, match="do not agree with the boxsize"):
+            CheckInput.check_units_coordinates(coords, 1.5)
+        CheckInput.check_units_coordinates(coords, 2.5)  # in range, must not raise
+
+    def test_check_type_input_data_rejects_bad_los(self):
+        cat = _box_catalog(N=5)
+        cat["LOS"] = 5
+        with pytest.raises(AssertionError):
+            CheckInput.check_type_input_data(
+                cat, ("Position", "Position_shape_sample", "Axis_Direction", "q", "LOS"))
+
+    def test_check_type_input_data_rejects_bad_shape(self):
+        cat = _box_catalog(N=5)
+        cat["Position"] = cat["Position"][:, :2]
+        with pytest.raises(AssertionError):
+            CheckInput.check_type_input_data(
+                cat, ("Position", "Position_shape_sample", "Axis_Direction", "q", "LOS"))
+
+    def test_jackknife_warning_max_separation(self):
+        with pytest.warns(UserWarning, match="maximum separation exceeds"):
+            CheckInput.check_jackknife_max_separation(64, 200, 60, 10)
+
+    def test_jackknife_warning_num_r_bins(self):
+        with pytest.warns(UserWarning, match="too many r"):
+            CheckInput.check_jackknife_max_separation(64, 200, 40, 15)
+
+    def test_jackknife_no_warning(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            CheckInput.check_jackknife_max_separation(8, 200, 20, 8)
+
+    def test_rename_input_keys(self):
+        renamed = CheckInput.rename_input_keys(
+            {"COM": 1, "extra": 2}, {"COM": "Position"})
+        assert renamed == {"Position": 1, "extra": 2}
+
+    def test_rename_input_keys_none(self):
+        assert CheckInput.rename_input_keys(None, {"COM": "Position"}) is None
+
+
+# ---------------------------------------------------------------------------
+# 2. MeasureIABox wiring
+# ---------------------------------------------------------------------------
+
+class TestBoxInputChecks:
+    def test_missing_key_raises(self, tmp_path):
+        cat = _box_catalog()
+        del cat["Axis_Direction"]
+        with pytest.raises(KeyError, match="does not contain Axis_Direction"):
+            MeasureIABox(cat, str(tmp_path / "o.hdf5"), boxsize=BOXSIZE)
+
+    def test_custom_name_missing_under_default_raises(self, tmp_path):
+        cat = _renamed(_box_catalog(), _BOX_RENAME)
+        with pytest.raises(KeyError, match="does not contain Position"):
+            MeasureIABox(cat, str(tmp_path / "o.hdf5"), boxsize=BOXSIZE)
+
+    def test_coordinates_outside_boxsize_raise(self, tmp_path):
+        cat = _box_catalog()
+        with pytest.raises(ValueError, match="do not agree with the boxsize"):
+            MeasureIABox(cat, str(tmp_path / "o.hdf5"), boxsize=BOXSIZE / 10.0)
+
+    def test_output_folder_must_exist(self, tmp_path):
+        cat = _box_catalog()
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            MeasureIABox(cat, str(tmp_path / "missing_dir" / "o.hdf5"), boxsize=BOXSIZE)
+
+    def test_jackknife_separation_warning(self, tmp_path):
+        cat = _box_catalog()
+        obj = MeasureIABox(cat, str(tmp_path / "o.hdf5"), boxsize=BOXSIZE,
+                           separation_limits=[0.1, 60.0])
+        with pytest.warns(UserWarning, match="maximum separation exceeds"):
+            obj.measure_xi_w("warn_jk", "g+", num_jk=64, temp_file_path=False)
+
+    def test_custom_names_bit_identical(self, tmp_path):
+        cat = _box_catalog()
+        obj_def = MeasureIABox(cat, str(tmp_path / "def.hdf5"), boxsize=BOXSIZE)
+        obj_def.measure_xi_w("t", "both", temp_file_path=False)
+
+        obj_cus = MeasureIABox(_renamed(cat, _BOX_RENAME), str(tmp_path / "cus.hdf5"),
+                               boxsize=BOXSIZE, **_BOX_NAME_KWARGS)
+        obj_cus.measure_xi_w("t", "both", temp_file_path=False)
+
+        with h5py.File(tmp_path / "def.hdf5") as fd, h5py.File(tmp_path / "cus.hdf5") as fc:
+            for ds in ("w_g_plus/t", "w_gg/t"):
+                assert np.array_equal(fd[ds][:], fc[ds][:])
+
+    def test_custom_named_masks_bit_identical(self, tmp_path):
+        cat = _box_catalog()
+        N = len(cat["q"])
+        mask = np.zeros(N, dtype=bool)
+        mask[: N // 2] = True
+        masks_def = {"Position": mask, "Position_shape_sample": mask,
+                     "Axis_Direction": mask, "q": mask}
+        obj_def = MeasureIABox(cat, str(tmp_path / "def.hdf5"), boxsize=BOXSIZE)
+        obj_def.measure_xi_w("t", "g+", temp_file_path=False, masks=masks_def)
+
+        obj_cus = MeasureIABox(_renamed(cat, _BOX_RENAME), str(tmp_path / "cus.hdf5"),
+                               boxsize=BOXSIZE, **_BOX_NAME_KWARGS)
+        obj_cus.measure_xi_w("t", "g+", temp_file_path=False,
+                             masks=_renamed(masks_def, _BOX_RENAME))
+
+        with h5py.File(tmp_path / "def.hdf5") as fd, h5py.File(tmp_path / "cus.hdf5") as fc:
+            assert np.array_equal(fd["w_g_plus/t"][:], fc["w_g_plus/t"][:])
+
+    def test_user_dict_not_mutated(self, tmp_path):
+        cat = _box_catalog()
+        keys_before = set(cat.keys())
+        MeasureIABox(cat, str(tmp_path / "o.hdf5"), boxsize=BOXSIZE)
+        assert set(cat.keys()) == keys_before  # default weights go to the remapped copy
+
+
+# ---------------------------------------------------------------------------
+# 3. MeasureIALightcone wiring
+# ---------------------------------------------------------------------------
+
+class TestLightconeInputChecks:
+    def test_missing_key_raises(self, tmp_path):
+        data, randoms = _lc_catalogs()
+        del data["e2"]
+        with pytest.raises(KeyError, match="does not contain e2"):
+            MeasureIALightcone(data, randoms, str(tmp_path / "o.hdf5"), pi_max=60)
+
+    def test_randoms_missing_key_raises(self, tmp_path):
+        data, randoms = _lc_catalogs()
+        del randoms["RA"]
+        with pytest.raises(KeyError, match="does not contain RA"):
+            MeasureIALightcone(data, randoms, str(tmp_path / "o.hdf5"), pi_max=60)
+
+    def test_custom_name_missing_under_default_raises(self, tmp_path):
+        data, randoms = _lc_catalogs()
+        with pytest.raises(KeyError, match="does not contain ra_d"):
+            MeasureIALightcone(data, randoms, str(tmp_path / "o.hdf5"), pi_max=60,
+                               **_LC_NAME_KWARGS)
+
+    def test_custom_names_bit_identical(self, tmp_path):
+        data, randoms = _lc_catalogs()
+        kwargs = dict(separation_limits=[2.0, 20.0], num_bins_r=5, num_bins_pi=10,
+                      pi_max=60)
+        obj_def = MeasureIALightcone(dict(data), dict(randoms),
+                                     str(tmp_path / "def.hdf5"), **kwargs)
+        obj_def.measure_xi_w("galaxies", "t", "both", measure_cov=False)
+
+        obj_cus = MeasureIALightcone(_renamed(data, _LC_RENAME),
+                                     _renamed(randoms, _LC_RENAME),
+                                     str(tmp_path / "cus.hdf5"), **kwargs,
+                                     **_LC_NAME_KWARGS)
+        obj_cus.measure_xi_w("galaxies", "t", "both", measure_cov=False)
+
+        with h5py.File(tmp_path / "def.hdf5") as fd, h5py.File(tmp_path / "cus.hdf5") as fc:
+            for ds in ("w_g_plus/t", "w_gg/t"):
+                assert np.array_equal(fd[ds][:], fc[ds][:])
+
+    def test_custom_names_jk_cov_bit_identical(self, tmp_path):
+        data, randoms = _lc_catalogs(N=120, NR=360)
+        kwargs = dict(separation_limits=[2.0, 20.0], num_bins_r=5, num_bins_pi=10,
+                      pi_max=60)
+        obj_def = MeasureIALightcone(dict(data), dict(randoms),
+                                     str(tmp_path / "def.hdf5"), **kwargs)
+        obj_def.measure_xi_w("galaxies", "t", "g+", num_jk=4, seed=3)
+
+        obj_cus = MeasureIALightcone(_renamed(data, _LC_RENAME),
+                                     _renamed(randoms, _LC_RENAME),
+                                     str(tmp_path / "cus.hdf5"), **kwargs,
+                                     **_LC_NAME_KWARGS)
+        obj_cus.measure_xi_w("galaxies", "t", "g+", num_jk=4, seed=3)
+
+        with h5py.File(tmp_path / "def.hdf5") as fd, h5py.File(tmp_path / "cus.hdf5") as fc:
+            assert np.array_equal(fd["w_g_plus/t_jackknife_cov_4"][:],
+                                  fc["w_g_plus/t_jackknife_cov_4"][:], equal_nan=True)
+
+    def test_user_dicts_not_mutated(self, tmp_path):
+        data, randoms = _lc_catalogs()
+        data_keys = set(data.keys())
+        randoms_keys = set(randoms.keys())
+        obj = MeasureIALightcone(data, randoms, str(tmp_path / "o.hdf5"),
+                                 separation_limits=[2.0, 20.0], num_bins_r=5,
+                                 num_bins_pi=10, pi_max=60)
+        obj.measure_xi_w("galaxies", "t", "gg", measure_cov=False)
+        assert set(data.keys()) == data_keys  # weight defaults go to the remapped copies
+        assert set(randoms.keys()) == randoms_keys


### PR DESCRIPTION
## Summary
- Adds `CheckInput` class: required-key, type/shape, coordinate-unit and output-path validation plus key-name remapping
- `MeasureIABox` and `MeasureIALightcone` accept `*_name` kwargs so data, randoms and mask dictionaries can use any key names; keys are remapped to the internal defaults at entry (backends untouched)
- Jackknife subbox-size warnings in the box measure methods
- EAGLE accepts `snapshot=None`; clearer error when a subhalo file fails to open
- 25 new tests incl. bit-identity checks of custom vs default names (suite: 497 passed, 3 xfailed)

Rebuilt from the April `limit_input_options` work (old tip ad51b9a) on current dev, completing the wip lightcone generalisation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)